### PR TITLE
Overhaul event handling for external editor plugins

### DIFF
--- a/Collection/HelperCollection.php
+++ b/Collection/HelperCollection.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Zikula\ScribiteModule\Collection;
 
 /**
- * This class is used as the subject of \Zikula\ScribiteModule\Event\EditorHelperEvent
+ * This class is used as the subject of `\Zikula\ScribiteModule\Event\EditorHelperEvent`.
  * Any module that needs to add page assets (javascript, css) can use an event listener to automatically load their
  * helper every time a Scribite editor is loaded.
  */

--- a/Editor/CKEditor/Collection/PluginCollection.php
+++ b/Editor/CKEditor/Collection/PluginCollection.php
@@ -1,45 +1,40 @@
 <?php
 
 declare(strict_types=1);
-/**
- * Zikula Application Framework
+
+/*
+ * This file is part of the Zikula package.
  *
- * @copyright  (c) Zikula Development Team
- * @see       https://ziku.la
- * @license    GNU/GPL - http://www.gnu.org/copyleft/gpl.html
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Zikula\ScribiteModule\Editor\CKEditor\Collection;
 
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
+
 /**
- * This class is used as the subject of the event 'moduleplugin.ckeditor.externalplugins'.
- * Any module that needs to add *external* editor plugins can use an event listener to automatically load their
+ * This class is used by the `Zikula\ScribiteModule\Editor\CKEditor\LoadExternalPluginsEvent`.
+ * Any extension that needs to add *external* editor plugins can use an event listener to automatically load their
  * helper every time a Scribite editor is loaded.
  * @see http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.resourceManager.html#addExternal
  * @see http://ckeditor.com/comment/47922#comment-47922
  */
-class PluginCollection
+class PluginCollection implements EditorPluginCollectionInterface
 {
     /**
-     * stack of plugins
-     * @var array
+     * Stack of plugins.
      */
-    private $plugins;
+    private $plugins = [];
 
     /**
-     * PluginCollection constructor.
+     * Adds a plugin to the stack.
+     *
+     * $plugin must have array keys [name, path, file, img] set.
      */
-    public function __construct()
-    {
-        $this->plugins = [];
-    }
-
-    /**
-     * add a plugin to the stack
-     * @param array $plugin
-     * $helper must have array keys [name, path, file, img] set
-     */
-    public function add(array $plugin)
+    public function add(array $plugin): void
     {
         if (isset($plugin['name'], $plugin['path'], $plugin['file'], $plugin['img'])) {
             $plugin['path'] = rtrim($plugin['path'], '/') . '/'; // ensure there is a trailing slash
@@ -48,10 +43,9 @@ class PluginCollection
     }
 
     /**
-     * get the helper stack
-     * @return array
+     * Gets the plugins stack.
      */
-    public function getPlugins()
+    public function getPlugins(): array
     {
         return $this->plugins;
     }

--- a/Editor/CKEditor/Helper/EditorHelper.php
+++ b/Editor/CKEditor/Helper/EditorHelper.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Zikula\ScribiteModule\Editor\CKEditor\Helper;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Zikula\Bundle\CoreBundle\Event\GenericEvent;
 use Zikula\ScribiteModule\Editor\CKEditor\Collection\PluginCollection;
 use Zikula\ScribiteModule\Editor\EditorHelperInterface;
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
 
 class EditorHelper implements EditorHelperInterface
 {
@@ -25,9 +25,6 @@ class EditorHelper implements EditorHelperInterface
      */
     private $dispatcher;
 
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     */
     public function __construct(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
@@ -44,14 +41,8 @@ class EditorHelper implements EditorHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getExternalPlugins(): array
+    public function getPluginCollection(): EditorPluginCollectionInterface
     {
-        if (null === $this->dispatcher) {
-            throw new \RuntimeException('Dispatcher has not been set.');
-        }
-        $event = new GenericEvent(new PluginCollection());
-        $plugins = $this->dispatcher->dispatch($event, 'moduleplugin.ckeditor.externalplugins')->getSubject()->getPlugins();
-
-        return $plugins;
+        return new PluginCollection();
     }
 }

--- a/Editor/EditorPluginCollectionInterface.php
+++ b/Editor/EditorPluginCollectionInterface.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace Zikula\ScribiteModule\Editor;
 
-interface EditorHelperInterface
+interface EditorPluginCollectionInterface
 {
     /**
-     * An array of parameters which will be added to the template within the
-     * property `editorParameters`
+     * Add a plugin to the stack.
+     * Array structure depends on the editor's requirements.
      */
-    public function getParameters(): array;
+    public function add(array $plugin): void;
 
     /**
-     * A collection containing definitions for external editor plugins
+     * Gets the plugins stack.
      */
-    public function getPluginCollection(): EditorPluginCollectionInterface;
+    public function getPlugins(): array;
 }

--- a/Editor/Factory.php
+++ b/Editor/Factory.php
@@ -20,6 +20,7 @@ use Zikula\ExtensionsModule\Api\ApiInterface\VariableApiInterface;
 use Zikula\ScribiteModule\Collection\HelperCollection;
 use Zikula\ScribiteModule\Collector\EditorCollector;
 use Zikula\ScribiteModule\Event\EditorHelperEvent;
+use Zikula\ScribiteModule\Event\LoadExternalPluginsEvent;
 use Zikula\ScribiteModule\Helper\AssetHelper;
 use Zikula\ThemeModule\Api\ApiInterface\PageAssetApiInterface;
 
@@ -115,7 +116,10 @@ class Factory
                 throw new \RuntimeException(sprintf('%s must implement %s', get_class($editorHelper), EditorHelperInterface::class));
             }
             $additionalEditorParameters = $editorHelper->getParameters();
-            $additionalExternalEditorPlugins = $editorHelper->getExternalPlugins();
+            /** @var EditorPluginCollectionInterface $additionalExternalEditorPlugins */
+            $additionalExternalEditorPlugins = $editorHelper->getPluginCollection();
+            $event = new LoadExternalPluginsEvent($additionalExternalEditorPlugins, $editorId);
+            $additionalExternalEditorPlugins = $this->dispatcher->dispatch($event)->getPluginCollection()->getPlugins();
         }
 
         // assign disabled textareas to template as a javascript array

--- a/Editor/Quill/Collection/PluginCollection.php
+++ b/Editor/Quill/Collection/PluginCollection.php
@@ -1,44 +1,39 @@
 <?php
 
 declare(strict_types=1);
-/**
- * Zikula Application Framework
+
+/*
+ * This file is part of the Zikula package.
  *
- * @copyright  (c) Zikula Development Team
- * @see       https://ziku.la
- * @license    GNU/GPL - http://www.gnu.org/copyleft/gpl.html
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Zikula\ScribiteModule\Editor\Quill\Collection;
 
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
+
 /**
- * This class is used as the subject of the event 'moduleplugin.quill.externalplugins'.
- * Any module that needs to add *external* editor plugins can use an event listener to automatically load their
+ * This class is used by the `Zikula\ScribiteModule\Editor\Quill\LoadExternalPluginsEvent`.
+ * Any extension that needs to add *external* editor plugins can use an event listener to automatically load their
  * helper every time a Scribite editor is loaded.
  * @see https://quilljs.com/docs/modules/
  */
-class PluginCollection
+class PluginCollection implements EditorPluginCollectionInterface
 {
     /**
-     * stack of plugins
-     * @var array
+     * Stack of plugins.
      */
-    private $plugins;
+    private $plugins = [];
 
     /**
-     * PluginCollection constructor.
+     * Adds a plugin to the stack.
+     *
+     * $plugin must have array keys [name, path] set.
      */
-    public function __construct()
-    {
-        $this->plugins = [];
-    }
-
-    /**
-     * add a plugin to the stack
-     * @param array $plugin
-     * $helper must have array keys [name, path] set
-     */
-    public function add(array $plugin)
+    public function add(array $plugin): void
     {
         if (isset($plugin['name'], $plugin['path'])) {
             $this->plugins[] = $plugin;
@@ -46,10 +41,9 @@ class PluginCollection
     }
 
     /**
-     * get the helper stack
-     * @return array
+     * Gets the plugins stack.
      */
-    public function getPlugins()
+    public function getPlugins(): array
     {
         return $this->plugins;
     }

--- a/Editor/Quill/Helper/EditorHelper.php
+++ b/Editor/Quill/Helper/EditorHelper.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /*
  * This file is part of the Zikula package.
  *
@@ -13,8 +14,8 @@ declare(strict_types=1);
 namespace Zikula\ScribiteModule\Editor\Quill\Helper;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Zikula\Bundle\CoreBundle\Event\GenericEvent;
 use Zikula\ScribiteModule\Editor\EditorHelperInterface;
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
 use Zikula\ScribiteModule\Editor\Quill\Collection\PluginCollection;
 
 class EditorHelper implements EditorHelperInterface
@@ -24,9 +25,6 @@ class EditorHelper implements EditorHelperInterface
      */
     private $dispatcher;
 
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     */
     public function __construct(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
@@ -43,14 +41,8 @@ class EditorHelper implements EditorHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getExternalPlugins(): array
+    public function getPluginCollection(): EditorPluginCollectionInterface
     {
-        if (null === $this->dispatcher) {
-            throw new \RuntimeException('Dispatcher has not been set.');
-        }
-        $event = new GenericEvent(new PluginCollection());
-        $plugins = $this->dispatcher->dispatch($event, 'moduleplugin.quill.externalplugins')->getSubject()->getPlugins();
-
-        return $plugins;
+        return new PluginCollection();
     }
 }

--- a/Editor/Summernote/Collection/PluginCollection.php
+++ b/Editor/Summernote/Collection/PluginCollection.php
@@ -1,44 +1,38 @@
 <?php
 
 declare(strict_types=1);
-/**
- * Zikula Application Framework
+
+/*
+ * This file is part of the Zikula package.
  *
- * @copyright  (c) Zikula Development Team
- * @see       https://ziku.la
- * @license    GNU/GPL - http://www.gnu.org/copyleft/gpl.html
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Zikula\ScribiteModule\Editor\Summernote\Collection;
 
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
+
 /**
- * This class is used as the subject of the event 'moduleplugin.summernote.externalplugins'.
- * Any module that needs to add *external* editor plugins can use an event listener to automatically load their
+ * This class is used by the `Zikula\ScribiteModule\Editor\Summernote\LoadExternalPluginsEvent`.
+ * Any extension that needs to add *external* editor plugins can use an event listener to automatically load their
  * helper every time a Scribite editor is loaded.
  * @see http://summernote.org/deep-dive/#module-system
  */
-class PluginCollection
+class PluginCollection implements EditorPluginCollectionInterface
 {
     /**
-     * stack of plugins
-     * @var array
+     * Stack of plugins.
      */
-    private $plugins;
-
+    private $plugins = [];
     /**
-     * PluginCollection constructor.
+     * Adds a plugin to the stack.
+     *
+     * $plugin must have array keys [name, path] set.
      */
-    public function __construct()
-    {
-        $this->plugins = [];
-    }
-
-    /**
-     * add a plugin to the stack
-     * @param array $plugin
-     * $helper must have array keys [name, path] set
-     */
-    public function add(array $plugin)
+    public function add(array $plugin): void
     {
         if (isset($plugin['name'], $plugin['path'])) {
             $this->plugins[] = $plugin;
@@ -46,10 +40,9 @@ class PluginCollection
     }
 
     /**
-     * get the helper stack
-     * @return array
+     * Gets the plugins stack.
      */
-    public function getPlugins()
+    public function getPlugins(): array
     {
         return $this->plugins;
     }

--- a/Editor/Summernote/Collection/PluginCollection.php
+++ b/Editor/Summernote/Collection/PluginCollection.php
@@ -27,6 +27,7 @@ class PluginCollection implements EditorPluginCollectionInterface
      * Stack of plugins.
      */
     private $plugins = [];
+
     /**
      * Adds a plugin to the stack.
      *

--- a/Editor/Summernote/Helper/EditorHelper.php
+++ b/Editor/Summernote/Helper/EditorHelper.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Zikula\ScribiteModule\Editor\Summernote\Helper;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Zikula\Bundle\CoreBundle\Event\GenericEvent;
 use Zikula\ScribiteModule\Editor\EditorHelperInterface;
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
 use Zikula\ScribiteModule\Editor\Summernote\Collection\PluginCollection;
 
 class EditorHelper implements EditorHelperInterface
@@ -24,9 +24,6 @@ class EditorHelper implements EditorHelperInterface
      */
     private $dispatcher;
 
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     */
     public function __construct(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
@@ -43,14 +40,8 @@ class EditorHelper implements EditorHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getExternalPlugins(): array
+    public function getPluginCollection(): EditorPluginCollectionInterface
     {
-        if (null === $this->dispatcher) {
-            throw new \RuntimeException('Dispatcher has not been set.');
-        }
-        $event = new GenericEvent(new PluginCollection());
-        $plugins = $this->dispatcher->dispatch($event, 'moduleplugin.summernote.externalplugins')->getSubject()->getPlugins();
-
-        return $plugins;
+        return new PluginCollection();
     }
 }

--- a/Editor/TinyMce/Collection/PluginCollection.php
+++ b/Editor/TinyMce/Collection/PluginCollection.php
@@ -1,44 +1,39 @@
 <?php
 
 declare(strict_types=1);
-/**
- * Zikula Application Framework
+
+/*
+ * This file is part of the Zikula package.
  *
- * @copyright  (c) Zikula Development Team
- * @see       https://ziku.la
- * @license    GNU/GPL - http://www.gnu.org/copyleft/gpl.html
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Zikula\ScribiteModule\Editor\TinyMce\Collection;
 
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
+
 /**
- * This class is used as the subject of the event 'moduleplugin.tinymce.externalplugins'.
- * Any module that needs to add *external* editor plugins can use an event listener to automatically load their
+ * This class is used by the `Zikula\ScribiteModule\Editor\TinyMce\LoadExternalPluginsEvent`.
+ * Any extension that needs to add *external* editor plugins can use an event listener to automatically load their
  * helper every time a Scribite editor is loaded.
  * @see http://www.tinymce.com/wiki.php/Configuration:plugins
  */
-class PluginCollection
+class PluginCollection implements EditorPluginCollectionInterface
 {
     /**
-     * stack of plugins
-     * @var array
+     * Stack of plugins.
      */
-    private $plugins;
+    private $plugins = [];
 
     /**
-     * PluginCollection constructor.
+     * Adds a plugin to the stack.
+     *
+     * $plugin must have array keys [name, path] set.
      */
-    public function __construct()
-    {
-        $this->plugins = [];
-    }
-
-    /**
-     * add a plugin to the stack
-     * @param array $plugin
-     * $helper must have array keys [name, path] set
-     */
-    public function add(array $plugin)
+    public function add(array $plugin): void
     {
         if (isset($plugin['name'], $plugin['path'])) {
             $this->plugins[] = $plugin;
@@ -46,10 +41,9 @@ class PluginCollection
     }
 
     /**
-     * get the helper stack
-     * @return array
+     * Gets the plugins stack.
      */
-    public function getPlugins()
+    public function getPlugins(): array
     {
         return $this->plugins;
     }

--- a/Editor/TinyMce/Helper/EditorHelper.php
+++ b/Editor/TinyMce/Helper/EditorHelper.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Zikula\ScribiteModule\Editor\TinyMce\Helper;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Zikula\Bundle\CoreBundle\Event\GenericEvent;
 use Zikula\ScribiteModule\Editor\EditorHelperInterface;
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
 use Zikula\ScribiteModule\Editor\TinyMce\Collection\PluginCollection;
 
 class EditorHelper implements EditorHelperInterface
@@ -29,10 +29,6 @@ class EditorHelper implements EditorHelperInterface
      */
     private $parameters;
 
-    /**
-     * @param EventDispatcherInterface $dispatcher
-     * @param array $parameters
-     */
     public function __construct(
         EventDispatcherInterface $dispatcher,
         array $parameters
@@ -94,14 +90,8 @@ class EditorHelper implements EditorHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function getExternalPlugins(): array
+    public function getPluginCollection(): EditorPluginCollectionInterface
     {
-        if (null === $this->dispatcher) {
-            throw new \RuntimeException('Dispatcher has not been set.');
-        }
-        $event = new GenericEvent(new PluginCollection());
-        $plugins = $this->dispatcher->dispatch($event, 'moduleplugin.tinymce.externalplugins')->getSubject()->getPlugins();
-
-        return $plugins;
+        return new PluginCollection();
     }
 }

--- a/Event/EditorHelperEvent.php
+++ b/Event/EditorHelperEvent.php
@@ -32,24 +32,18 @@ class EditorHelperEvent
      */
     private $editor;
 
-    public function __construct($helpers, $editor)
+    public function __construct(HelperCollection $helpers, string $editor)
     {
-        $this->editor = $editor;
         $this->helperCollection = $helpers;
+        $this->editor = $editor;
     }
 
-    /**
-     * @return HelperCollection
-     */
-    public function getHelperCollection()
+    public function getHelperCollection(): HelperCollection
     {
         return $this->helperCollection;
     }
 
-    /**
-     * @return string
-     */
-    public function getEditor()
+    public function getEditor(): string
     {
         return $this->editor;
     }

--- a/Event/LoadExternalPluginsEvent.php
+++ b/Event/LoadExternalPluginsEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Zikula package.
+ *
+ * Copyright Zikula Foundation - https://ziku.la/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zikula\ScribiteModule\Event;
+
+use Zikula\ScribiteModule\Editor\EditorPluginCollectionInterface;
+
+/**
+ * This event occurs when Scribite is loading additional plugins for CKEditor.
+ * The subscribing extension should use the EditorPluginCollectionInterface::add() method to add an array.
+ * Please see the class docs for more.
+ */
+class LoadExternalPluginsEvent
+{
+    /**
+     * @var EditorPluginCollectionInterface
+     */
+    private $pluginCollection;
+
+    /**
+     * @var string
+     */
+    private $editor;
+
+    public function __construct(EditorPluginCollectionInterface $plugins, string $editor)
+    {
+        $this->pluginCollection = $plugins;
+        $this->editor = $editor;
+    }
+
+    public function getPluginCollection(): EditorPluginCollectionInterface
+    {
+        return $this->pluginCollection;
+    }
+
+    public function getEditor(): string
+    {
+        return $this->editor;
+    }
+}


### PR DESCRIPTION
- introduce dedicated event class for collecting external plugins
- use only one `LoadExternalPluginsEvent` instead of distinct events for each editor
- introduce `EditorPluginCollectionInterface` as common denominator instead
- simplify `EditorHelperInterface` to return only the plugin collection
- dispatch the event at a central place (inside the factory instead of inside every single editor helper)